### PR TITLE
Branchionaire

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,4 +1,4 @@
-*Current build status:* [![Travis CI](https://travis-ci.org/1and1/fralax.svg?branch=master)](https://travis-ci.org/1and1/fralax) [![Codacy Badge](https://api.codacy.com/project/badge/grade/021a8a9c3b454ad9a72066051fd5b29c)](https://www.codacy.com/app/sysdev/fralax)
+*Current build status:* [![Travis CI](https://travis-ci.org/1and1/fralax.svg?branch=master)](https://travis-ci.org/1and1/fralax) [![Codacy Badge](https://api.codacy.com/project/badge/grade/021a8a9c3b454ad9a72066051fd5b29c)](https://www.codacy.com/app/sysdev/fralax) [![Codacy Badge](https://api.codacy.com/project/badge/coverage/021a8a9c3b454ad9a72066051fd5b29c)](https://www.codacy.com/app/1and1_NDev/fralax)
 
 **Framework for Large XML File Parsing \[FraLaX\]**
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,9 @@ repositories {
 }
 
 dependencies {
-    compile 'com.ximpleware:vtd-xml:2.11'
+    compile group: 'com.ximpleware', name: 'vtd-xml', version: '2.11'
     compile group: 'org.projectlombok', name: 'lombok', version: '1.16.8'
-    testCompile 'junit:junit:4.12'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 
 test {

--- a/src/main/java/net/onenandone/fralax/Fralax.java
+++ b/src/main/java/net/onenandone/fralax/Fralax.java
@@ -7,9 +7,6 @@ import java.util.Objects;
 /**
  * Factory used to create the default (Vtd) XMLParser or a specific parser.
  * Requirement for the static factory function to work for new Implementations: Default constructor must be visible.
- *
- * @author Daniel Draper Johann Bähler
- * @version 1.0
  */
 public class Fralax {
 

--- a/src/main/java/net/onenandone/fralax/Fralax.java
+++ b/src/main/java/net/onenandone/fralax/Fralax.java
@@ -5,11 +5,11 @@ import net.onenandone.fralax.parser.VtdXmlParser;
 import java.util.Objects;
 
 /**
+ * Factory used to create the default (Vtd) XMLParser or a specific parser.
+ * Requirement for the static factory function to work for new Implementations: Default constructor must be visible.
+ *
  * @author Daniel Draper Johann Bähler
- *         Created on 06.04.16.
  * @version 1.0
- *          Factory used to create the default (Vtd) XMLParser or a specific parser.
- *          Requirement for the static factory function to work for new Implementations: Default constructor must be visible.
  */
 public class Fralax {
 

--- a/src/main/java/net/onenandone/fralax/FralaxException.java
+++ b/src/main/java/net/onenandone/fralax/FralaxException.java
@@ -2,9 +2,6 @@ package net.onenandone.fralax;
 
 /**
  * Exception thrown by Fralax-Related classes when errors occur during parsing.
- *
- * @author Daniel Draper Johann Bähler
- * @version 1.0
  */
 public class FralaxException extends RuntimeException {
 

--- a/src/main/java/net/onenandone/fralax/FralaxException.java
+++ b/src/main/java/net/onenandone/fralax/FralaxException.java
@@ -1,10 +1,10 @@
 package net.onenandone.fralax;
 
 /**
+ * Exception thrown by Fralax-Related classes when errors occur during parsing.
+ *
  * @author Daniel Draper Johann Bähler
- *         Created on 06.04.16.
  * @version 1.0
- *          Exception thrown by Fralax-Related classes when errors occur during parsing.
  */
 public class FralaxException extends RuntimeException {
 

--- a/src/main/java/net/onenandone/fralax/XmlContext.java
+++ b/src/main/java/net/onenandone/fralax/XmlContext.java
@@ -5,9 +5,6 @@ import java.util.Optional;
 
 /**
  * Represents a parsed XmlFile or result of an executed XPath-Query.
- *
- * @author Daniel Draper Johann Böhler
- * @version 1.0
  */
 public interface XmlContext {
 

--- a/src/main/java/net/onenandone/fralax/XmlContext.java
+++ b/src/main/java/net/onenandone/fralax/XmlContext.java
@@ -4,19 +4,22 @@ import java.util.List;
 import java.util.Optional;
 
 /**
+ * Represents a parsed XmlFile or result of an executed XPath-Query.
+ *
  * @author Daniel Draper Johann Böhler
- *         Created on 06.04.16.
  * @version 1.0
- *          Represents a parsed XmlFile or result of an executed XPath-Query.
  */
 public interface XmlContext {
 
     /**
      * Registers a namespace with this certain xml document for use when evaluating xpath requests.
-     * E.g. <code>XmlContext xml = Fralax.parse(fileToParse)
-     * xml.registerNamespace("ns", "http://www.google.com")
-     * xml.select("//ns:element") //now uses the namespace
-     * </code>
+     * E.g.
+     *
+     * XmlContext xml = Fralax.parse(fileToParse);
+     * xml.registerNamespace("ns", "http://www.google.com");
+     * xml.select("//ns:element"); //now uses the namespace
+     * }
+     * </pre>
      *
      * @param key   the key to register for the namespace.
      * @param value namespace value to register.
@@ -25,10 +28,14 @@ public interface XmlContext {
 
     /**
      * Searches for an XPathQuery and returns the result as an XmlContext if it exists{@link Optional#empty()} otherwise.
-     * E.g. <code>XmlContext xml = Fralax.parse(fileToParse)
-     * XmlContext objectRR1 = xml.select("//vehicle[@id='RR1']") //returns new XmlContext
-     * objectRR1.select("/vehicle-id") //returns the vehicle-id object only for the previously selected vehicle object
-     * </code>
+     * E.g.
+     * <pre>
+     * {@code
+     * XmlContext xml = Fralax.parse(fileToParse);
+     * XmlContext objectRR1 = xml.select("//vehicle[@id='RR1']"); //returns new XmlContext
+     * objectRR1.select("/vehicle-id"); //returns the vehicle-id object only for the previously selected vehicle object
+     * }
+     * </pre>
      *
      * @param xpath the xpath query to search for.
      * @return a new XmlContext that can be parsed using xpath again.
@@ -38,10 +45,14 @@ public interface XmlContext {
 
     /**
      * Searches for an XPathQuery and returns the result as a list of XmlContexts that again are parsable with xpath.
-     * E.g. <code>XmlContext xml = Fralax.parse(fileToParse)
-     * List\<XmlContext> vehicles = xml.selectAll("//vehicle") //returns new list of vehicles as parsed XmlContexts.
-     * vehicles.get(0).select("/vehicle-id") //returns the vehicle-id object only for the first element of the previously selected vehicles.
-     * </code>
+     * E.g.
+     * <pre>
+     * {@code
+     * XmlContext xml = Fralax.parse(fileToParse);
+     * List\<XmlContext> vehicles = xml.selectAll("//vehicle"); //returns new list of vehicles as parsed XmlContexts.
+     * vehicles.get(0).select("/vehicle-id"); //returns the vehicle-id object only for the first element of the previously selected vehicles.
+     * }
+     * </pre>
      *
      * @param xpath the xpath query to search for.
      * @return a new XmlContext that can be parsed using xpath again.

--- a/src/main/java/net/onenandone/fralax/XmlParser.java
+++ b/src/main/java/net/onenandone/fralax/XmlParser.java
@@ -1,10 +1,10 @@
 package net.onenandone.fralax;
 
 /**
+ * A simple XmlParser that supports loading ina file parsing it and supports further searches on the returned DOM (as an XmlContext).
+ *
  * @author Daniel Draper Johann Bähler
- *         Created on 05.04.16.
  * @version 1.0
- *          A simple XmlParser that supports loading ina file parsing it and supports further searches on the returned DOM (as an XmlContext).
  */
 public interface XmlParser {
 

--- a/src/main/java/net/onenandone/fralax/XmlParser.java
+++ b/src/main/java/net/onenandone/fralax/XmlParser.java
@@ -2,9 +2,6 @@ package net.onenandone.fralax;
 
 /**
  * A simple XmlParser that supports loading ina file parsing it and supports further searches on the returned DOM (as an XmlContext).
- *
- * @author Daniel Draper Johann Bähler
- * @version 1.0
  */
 public interface XmlParser {
 

--- a/src/main/java/net/onenandone/fralax/parser/ValueContext.java
+++ b/src/main/java/net/onenandone/fralax/parser/ValueContext.java
@@ -10,9 +10,6 @@ import java.util.Optional;
  * A XMLContext representing a single value in an XML document.
  * E.g what is returned after searching for a single attribute value ("/driver/@id")
  * Does not support further searching using xpath queries.
- *
- * @author Johann Bähler
- * @version 1.0
  */
 class ValueContext implements XmlContext {
 

--- a/src/main/java/net/onenandone/fralax/parser/ValueContext.java
+++ b/src/main/java/net/onenandone/fralax/parser/ValueContext.java
@@ -7,11 +7,12 @@ import java.util.List;
 import java.util.Optional;
 
 /**
+ * A XMLContext representing a single value in an XML document.
+ * E.g what is returned after searching for a single attribute value ("/driver/@id")
+ * Does not support further searching using xpath queries.
+ *
  * @author Johann Bähler
  * @version 1.0
- *          A XMLContext representing a single value in an XML document.
- *          E.g what is returned after searching for a single attribute value ("/driver/@id")
- *          Does not support further searching using xpath queries.
  */
 class ValueContext implements XmlContext {
 
@@ -26,42 +27,30 @@ class ValueContext implements XmlContext {
         this.value = value;
     }
 
+    /** Not supported. */
     @Override
-    /**
-     * Not Supported.
-     */
     public void registerNamespace(String key, String value) {
         throw new UnsupportedOperationException("cannot register namespace for value");
     }
 
+    /** Not supported. */
     @Override
-    /**
-     * Not Supported.
-     */
     public Optional<XmlContext> select(String xpath) throws FralaxException {
         throw new UnsupportedOperationException("cannot select elements within value context");
     }
 
+    /** Not supported. */
     @Override
-    /**
-     * Not Supported.
-     */
     public List<XmlContext> selectAll(String xpath) throws FralaxException {
         throw new UnsupportedOperationException("cannot select elements within value context");
     }
 
     @Override
-    /**
-     * @see XmlContext#asString()
-     */
     public String asString() {
         return value;
     }
 
     @Override
-    /**
-     * @see XmlContext#asFormattedString()
-     */
     public String asFormattedString() {
         return value;
     }

--- a/src/main/java/net/onenandone/fralax/parser/VtdXmlParser.java
+++ b/src/main/java/net/onenandone/fralax/parser/VtdXmlParser.java
@@ -11,9 +11,6 @@ import java.io.IOException;
 
 /**
  * A VtdXmlParser based on XPath and using <a href="http://vtd-xml.sourceforge.net/">VTD-XML</a> as the underlying parser.
- *
- * @author Daniel Draper Johann Bähler
- * @version 1.0
  */
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class VtdXmlParser implements XmlParser {

--- a/src/main/java/net/onenandone/fralax/parser/VtdXmlParser.java
+++ b/src/main/java/net/onenandone/fralax/parser/VtdXmlParser.java
@@ -10,18 +10,15 @@ import java.io.IOException;
 
 
 /**
+ * A VtdXmlParser based on XPath and using <a href="http://vtd-xml.sourceforge.net/">VTD-XML</a> as the underlying parser.
+ *
  * @author Daniel Draper Johann Bähler
- *         Created on 01.04.16.
  * @version 1.0
- *          A VtdXmlParser based on XPath and using <a href="http://vtd-xml.sourceforge.net/">VTD-XML</a> as the underlying parser.
  */
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class VtdXmlParser implements XmlParser {
 
     @Override
-    /**
-     * @see XmlParser#parse(String)
-     */
     public VtdXmlParserContext parse(final String file) {
         try {
             return new VtdXmlParserContext(file);

--- a/src/main/java/net/onenandone/fralax/parser/VtdXmlParserContext.java
+++ b/src/main/java/net/onenandone/fralax/parser/VtdXmlParserContext.java
@@ -11,10 +11,10 @@ import java.io.*;
 import java.util.*;
 
 /**
+ * Represents a valid XML Document parsed from a file. Can be further navigated using xpath queries.
+ *
  * @author Daniel Draper Johann Bähler
- *         Created on 06.04.16.
  * @version 1.0
- *          Represents a valid XML Document parsed from a file. Can be further navigated using xpath queries.
  */
 class VtdXmlParserContext implements XmlContext {
 
@@ -52,18 +52,13 @@ class VtdXmlParserContext implements XmlContext {
     }
 
     @Override
-    /**
-     * @see net.onenandone.fralax.XmlContext#registerNamespace(String, String)
-     */
     public void registerNamespace(String key, String value) {
         registeredNamespaces.put(key, value);
         addNamespacesToAutopilot(autopilot, registeredNamespaces);
     }
 
 
-    /**
-     * Adds all registered Namespaces to the Autopilot for evaluation.
-     */
+    /** Adds all registered Namespaces to the Autopilot for evaluation. */
     private static void addNamespacesToAutopilot(final AutoPilot autopilot, final Map<String, String> registeredNamespaces) {
         for (Map.Entry<String, String> entry : registeredNamespaces.entrySet()) {
             autopilot.declareXPathNameSpace(entry.getKey(), entry.getValue());
@@ -71,9 +66,6 @@ class VtdXmlParserContext implements XmlContext {
     }
 
     @Override
-    /**
-     * @see XmlContext#select(String)
-     */
     public Optional<XmlContext> select(String xpath) throws FralaxException {
         final List<XmlContext> result = selectAll(xpath);
         if (result.size() > 1) {
@@ -86,9 +78,6 @@ class VtdXmlParserContext implements XmlContext {
     }
 
     @Override
-    /**
-     * @see XmlContext#selectAll(String)
-     */
     public List<XmlContext> selectAll(String xpath) throws FralaxException {
         final List<XmlContext> xmlElements = new ArrayList<>();
 
@@ -126,9 +115,6 @@ class VtdXmlParserContext implements XmlContext {
     }
 
     @Override
-    /**
-     * @see XmlContext#asString()
-     */
     public String asString() {
         final VTDNav selectionNavigation = navigation.cloneNav();
         try {
@@ -159,9 +145,6 @@ class VtdXmlParserContext implements XmlContext {
     }
 
     @Override
-    /**
-     * @see XmlContext#asFormattedString()
-     */
     public String asFormattedString() {
         try {
             final Source xmlInput = new StreamSource(new StringReader(asString()));

--- a/src/main/java/net/onenandone/fralax/parser/VtdXmlParserContext.java
+++ b/src/main/java/net/onenandone/fralax/parser/VtdXmlParserContext.java
@@ -12,9 +12,6 @@ import java.util.*;
 
 /**
  * Represents a valid XML Document parsed from a file. Can be further navigated using xpath queries.
- *
- * @author Daniel Draper Johann Bähler
- * @version 1.0
  */
 class VtdXmlParserContext implements XmlContext {
 

--- a/src/test/java/net/onenandone/fralax/FralaxTest.java
+++ b/src/test/java/net/onenandone/fralax/FralaxTest.java
@@ -8,12 +8,6 @@ import java.util.Optional;
 
 import static org.junit.Assert.*;
 
-/*
-autopilot.selectXPath("/driverVehicleInfo/vehicle");
-autopilot.evalXPath();
-autopilot.selectXPath("name");
-autopilot.evalXPath();
- */
 public class FralaxTest {
 
     private XmlContext xml;


### PR DESCRIPTION
* Formatted Javadoc
    * Text before tags `@author` and `@version` 
    * `{@code ...}` instead of `<code></code>`
   * `<pre></pre>` for code blocks
   * Deleted inherited Javadoc
   * Javadoc before annotations (e.g. `@Override`)
* Added Codacy code coverage badge
* Unified gradle depedency notation
* Deleted `@author` and `@version` from Javadoc (git annotate and history can be used in my opinion, but we can discuss this - LGTM or not)