### PR TITLE
Refactored asString

### DIFF
--- a/src/main/java/net/onenandone/fralax/parser/ValueContext.java
+++ b/src/main/java/net/onenandone/fralax/parser/ValueContext.java
@@ -48,7 +48,7 @@ class ValueContext implements XmlContext {
     }
 
     @Override
-    public String asFormattedString() {
+    public String asString(final boolean formatted) {
         return value;
     }
 }

--- a/src/main/java/net/onenandone/fralax/parser/VtdXmlParserContext.java
+++ b/src/main/java/net/onenandone/fralax/parser/VtdXmlParserContext.java
@@ -4,9 +4,6 @@ import com.ximpleware.*;
 import net.onenandone.fralax.FralaxException;
 import net.onenandone.fralax.XmlContext;
 
-import javax.xml.transform.*;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
 import java.io.*;
 import java.util.*;
 
@@ -145,24 +142,6 @@ class VtdXmlParserContext implements XmlContext {
             return curElement;
         } catch (NavException e) {
             throw new FralaxException("failed to transform to string", e);
-        }
-    }
-
-    @Override
-    public String asFormattedString() {
-        try {
-            final Source xmlInput = new StreamSource(new StringReader(asString()));
-            final StringWriter stringWriter = new StringWriter();
-            final StreamResult xmlOutput = new StreamResult(stringWriter);
-            final TransformerFactory transformerFactory = TransformerFactory.newInstance();
-            transformerFactory.setAttribute("indent-number", 2);
-            final Transformer transformer = transformerFactory.newTransformer();
-            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-            transformer.transform(xmlInput, xmlOutput);
-            return xmlOutput.getWriter().toString();
-        } catch (final TransformerException e) {
-            throw new FralaxException("could not format string", e);
         }
     }
 

--- a/src/main/java/net/onenandone/fralax/parser/VtdXmlParserContext.java
+++ b/src/main/java/net/onenandone/fralax/parser/VtdXmlParserContext.java
@@ -19,7 +19,6 @@ class VtdXmlParserContext implements XmlContext {
     private VTDNav navigation;
     private Map<String, String> registeredNamespaces = new HashMap<>();
 
-
     /**
      * Default constructor used to create a newly parsed XMLContext from a certain file.
      *
@@ -53,7 +52,6 @@ class VtdXmlParserContext implements XmlContext {
         registeredNamespaces.put(key, value);
         addNamespacesToAutopilot(autopilot, registeredNamespaces);
     }
-
 
     /** Adds all registered Namespaces to the Autopilot for evaluation. */
     private static void addNamespacesToAutopilot(final AutoPilot autopilot, final Map<String, String> registeredNamespaces) {
@@ -114,68 +112,24 @@ class VtdXmlParserContext implements XmlContext {
     @Override
     public String asString() {
         final VTDNav selectionNavigation = navigation.cloneNav();
+        if (selectionNavigation.getCurrentIndex() == selectionNavigation.getRootIndex()) {
+            try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+                selectionNavigation.dumpXML(outputStream);
+                return outputStream.toString();
+            } catch (final IOException e) {
+                // try to create string otherwise
+            }
+        }
+
         try {
             final int index = selectionNavigation.getCurrentIndex();
-            String curElement = "<" + selectionNavigation.toNormalizedString(index);
+            String curElement = "<" + selectionNavigation.toNormalizedString(index).replaceFirst("(.*):", "");
             for (String attribute : evaluateAttributes()) {
                 curElement = curElement + " " + attribute;
             }
             curElement = curElement + ">";
             String curOldElement = curElement;
             final ChildrenAndSiblings childrenAndSiblings = evaluateChildrenAndSiblings(selectionNavigation.getCurrentDepth(), index, selectionNavigation.getCurrentDepth());
-            for (final String childChild : childrenAndSiblings.children) {
-                curElement = curElement + childChild;
-            }
-            for (final String childSibling : childrenAndSiblings.siblings) {
-                curElement = curElement + childSibling;
-            }
-            if (curOldElement.equals(curElement)) {
-                selectionNavigation.recoverNode(index);
-                curElement = curElement + selectionNavigation.getXPathStringVal();
-            }
-            curElement = curElement + "</" + selectionNavigation.toNormalizedString(index) + ">";
-
-            return curElement;
-        } catch (NavException e) {
-            throw new FralaxException("failed to transform to string", e);
-        }
-    }
-
-    @Override
-    public String asFormattedString() {
-        String toBeFormatted;
-        try {
-            toBeFormatted = asStringWithoutNamespaces();
-            final Source xmlInput = new StreamSource(new StringReader(toBeFormatted));
-            final StringWriter stringWriter = new StringWriter();
-            final StreamResult xmlOutput = new StreamResult(stringWriter);
-            final TransformerFactory transformerFactory = TransformerFactory.newInstance();
-            transformerFactory.setAttribute("indent-number", 2);
-            final Transformer transformer = transformerFactory.newTransformer();
-            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-            transformer.transform(xmlInput, xmlOutput);
-            return xmlOutput.getWriter().toString();
-        } catch (final TransformerException e) {
-            throw new FralaxException("could not format string", e);
-        }
-    }
-
-    /**
-     * Returns the XML Element(s) without any namespace prefixes, e.g. instead of <x:books></x:books> this will return <books></books>.
-     * @return the XML string representation unformatted without name space prefixes.
-     */
-    private String asStringWithoutNamespaces() {
-        final VTDNav selectionNavigation = navigation.cloneNav();
-        try {
-            final int index = selectionNavigation.getCurrentIndex();
-            String curElement = "<" + selectionNavigation.toNormalizedString(index).replaceFirst("(.*):", "");
-            for (String attribute : evaluateAttributes(false)) {
-                curElement = curElement + " " + attribute;
-            }
-            curElement = curElement + ">";
-            String curOldElement = curElement;
-            final ChildrenAndSiblings childrenAndSiblings = evaluateChildrenAndSiblings(selectionNavigation.getCurrentDepth(), index, selectionNavigation.getCurrentDepth(), false);
             for (final String childChild : childrenAndSiblings.children) {
                 curElement = curElement + childChild;
             }
@@ -194,46 +148,41 @@ class VtdXmlParserContext implements XmlContext {
         }
     }
 
-
-
-    private List<String> evaluateAttributes() throws NavException {
-        return evaluateAttributes(true);
+    @Override
+    public String asFormattedString() {
+        try {
+            final Source xmlInput = new StreamSource(new StringReader(asString()));
+            final StringWriter stringWriter = new StringWriter();
+            final StreamResult xmlOutput = new StreamResult(stringWriter);
+            final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            transformerFactory.setAttribute("indent-number", 2);
+            final Transformer transformer = transformerFactory.newTransformer();
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+            transformer.transform(xmlInput, xmlOutput);
+            return xmlOutput.getWriter().toString();
+        } catch (final TransformerException e) {
+            throw new FralaxException("could not format string", e);
+        }
     }
-
 
     /**
      * Used to get all Attributes of the Current Node.
      *
-     * @param withNamespaces to specify if namespaces are cut from attribute names (when false) or not (when true).
      * @return A List of all XMLAttributes in the current Node.
      * @throws NavException When an Error occurs navigating the attributes;
      */
-    private List<String> evaluateAttributes(final boolean withNamespaces) throws NavException {
+    private List<String> evaluateAttributes() throws NavException {
         final List<String> attributes = new ArrayList<>();
         final int attrCount = navigation.getAttrCount();
         final int curIndex = navigation.getCurrentIndex();
         for (int i = curIndex + 1; i < curIndex + 1 + attrCount * 2; i += 2) {
-            String attributeKey;
-            if (withNamespaces) {
-                attributeKey = navigation.toNormalizedString(i);
-            }
-            else {
-                attributeKey = navigation.toNormalizedString(i).replaceFirst("(.*):", "");
-            }
+            final String attributeKey = navigation.toNormalizedString(i).replaceFirst("(.*):", "");
             final String attributeValue = navigation.toRawString(i + 1);
             attributes.add(attributeKey + "=\"" + attributeValue + "\"");
         }
         return attributes;
     }
-
-
-    /**
-     * @see this#evaluateChildrenAndSiblings(int, int, int, boolean)
-     */
-    private ChildrenAndSiblings evaluateChildrenAndSiblings(final int rootDepth, final int parentIndex, final int startDepth) throws NavException {
-        return evaluateChildrenAndSiblings(rootDepth, parentIndex, startDepth, true);
-    }
-
 
     /**
      * Used to get All Children of the Current Node as Well as its Siblings. Uses Recursive DFS to find all nodes required then parses them into XMLElements
@@ -242,27 +191,16 @@ class VtdXmlParserContext implements XmlContext {
      * @param rootDepth   the rootDepth index we start the search from.
      * @param parentIndex the parent Index of the current search.
      * @param startDepth  the startDepth of the current iteration.
-     * @param withNamespaces to specify if namespaces are cut from all names (when false) or not (when true).
      * @return A List of Lists with 2 elements: Element at index 0 is the children of the current Node. Element at index 1 is the siblings of the current node.
      * @throws NavException Error that occurs when the traversing of Nodes fails.
      */
-    private ChildrenAndSiblings evaluateChildrenAndSiblings(final int rootDepth, final int parentIndex, final int startDepth, boolean withNamespaces) throws NavException {
+    private ChildrenAndSiblings evaluateChildrenAndSiblings(final int rootDepth, final int parentIndex, final int startDepth) throws NavException {
         ChildrenAndSiblings childrenAndSiblings = new ChildrenAndSiblings();
         //Traversing children, uses startDepth as a check as we don't need to traverse already visited child nodes.
         if (navigation.toElement(VTDNav.FIRST_CHILD) && startDepth < navigation.getCurrentDepth()) {
-            if (withNamespaces) {
-                traverse(rootDepth, startDepth, childrenAndSiblings.children, true);
-            }
-            else {
-                traverse(rootDepth, startDepth, childrenAndSiblings.children, false);
-            }
+            traverse(rootDepth, startDepth, childrenAndSiblings.children);
         } else {
-            if (withNamespaces) {
-                childrenAndSiblings.children.add(navigation.getXPathStringVal());
-            }
-            else {
-                childrenAndSiblings.children.add(navigation.getXPathStringVal().replaceFirst("(.*):", ""));
-            }
+            childrenAndSiblings.children.add(navigation.getXPathStringVal().replaceFirst("(.*):", ""));
         }
 
         //After traversing all children nodes we now go back to our parent element and traverse all our siblings.
@@ -271,54 +209,25 @@ class VtdXmlParserContext implements XmlContext {
         final int newStartDepth = startDepth - 1;
         //Traversing siblings, uses rootDepth in the check so we don't keep on checking siblings of the node we start our search from.
         if (navigation.toElement(VTDNav.NEXT_SIBLING) && rootDepth < navigation.getCurrentDepth()) {
-            if (withNamespaces) {
-                traverse(rootDepth, newStartDepth, childrenAndSiblings.siblings, true);
-            }
-            else {
-                traverse(rootDepth, newStartDepth, childrenAndSiblings.siblings, false);
-            }
-
+            traverse(rootDepth, newStartDepth, childrenAndSiblings.siblings);
         }
         return childrenAndSiblings;
     }
 
-    private void traverse(final int rootDepth, final int startDepth, final List<String> elements, final boolean withNamespaces) throws NavException {
+    private void traverse(final int rootDepth, final int startDepth, final List<String> elements) throws NavException {
         int curIndex = navigation.getCurrentIndex();
         String child = "<";
-        if (withNamespaces) {
-            child = child + navigation.toNormalizedString(curIndex);
+        child = child + navigation.toNormalizedString(curIndex).replaceFirst("(.*):", "");
+        for (final String attribute : evaluateAttributes()) {
+            child = child + " " + attribute;
         }
-        else {
-            child = child + navigation.toNormalizedString(curIndex).replaceFirst("(.*):", "");
-        }
-        if (withNamespaces) {
-            for (final String attribute : evaluateAttributes()) {
-                child = child + " " + attribute;
-            }
-        }
-        else {
-            for (final String attribute : evaluateAttributes(false)) {
-                child = child + " " + attribute;
-            }
-        }
-
         child = child + ">";
         ChildrenAndSiblings childrenAndSiblings;
-        if (withNamespaces) {
-            childrenAndSiblings = evaluateChildrenAndSiblings(rootDepth, curIndex, startDepth + 1);
-        }
-        else {
-            childrenAndSiblings = evaluateChildrenAndSiblings(rootDepth, curIndex, startDepth + 1, false);
-        }
+        childrenAndSiblings = evaluateChildrenAndSiblings(rootDepth, curIndex, startDepth + 1);
         for (final String childChild : childrenAndSiblings.children) {
             child = child + childChild;
         }
-        if (withNamespaces) {
-            child = child + "</" + navigation.toNormalizedString(curIndex) + ">";
-        }
-        else {
-            child = child + "</" + navigation.toNormalizedString(curIndex).replaceFirst("(.*):", "") + ">";
-        }
+        child = child + "</" + navigation.toNormalizedString(curIndex).replaceFirst("(.*):", "") + ">";
         elements.add(child);
         elements.addAll(childrenAndSiblings.siblings);
     }

--- a/src/test/java/net/onenandone/fralax/FralaxQualifiedNamespaceTest.java
+++ b/src/test/java/net/onenandone/fralax/FralaxQualifiedNamespaceTest.java
@@ -39,7 +39,7 @@ public class FralaxQualifiedNamespaceTest {
                 "        <x:review>Least poetic poems.</x:review>\n" +
                 "    </x:book>\n" +
                 "</x:books>\n",
-                xml.asFormattedString()
+                xml.asString(true)
         );
     }
 
@@ -133,7 +133,7 @@ public class FralaxQualifiedNamespaceTest {
                         "  <pub_date>2000-10-01</pub_date>\n" +
                         "  <review>An amazing story of nothing.</review>\n" +
                         "</book>\n",
-                optionalContext.get().asFormattedString()
+                optionalContext.get().asString(true)
         );
     }
 
@@ -141,8 +141,8 @@ public class FralaxQualifiedNamespaceTest {
     public void testSelectListOfAttributes() throws Exception {
         final List<XmlContext> contexts = xml.selectAll("//@id");
         assertEquals(2, contexts.size());
-        assertEquals("bk001", contexts.get(0).asFormattedString());
-        assertEquals("bk002", contexts.get(1).asFormattedString());
+        assertEquals("bk001", contexts.get(0).asString(true));
+        assertEquals("bk002", contexts.get(1).asString(true));
     }
 
     @Test(expected = FralaxException.class)

--- a/src/test/java/net/onenandone/fralax/FralaxQualifiedNamespaceTest.java
+++ b/src/test/java/net/onenandone/fralax/FralaxQualifiedNamespaceTest.java
@@ -20,24 +20,27 @@ public class FralaxQualifiedNamespaceTest {
 
     @Test
     public void setNoSelectToString() throws  Exception {
-        String s = xml.asFormattedString();
-        assertEquals("<books>\n" +
-        "  <book id=\"bk001\">\n" +
-        "    <author>Writer</author>\n" +
-        "    <title>The First Book</title>\n" +
-        "    <genre>Fiction</genre>\n" +
-        "    <price>44.95</price>\n" +
-        "    <pub_date>2000-10-01</pub_date>\n" +
-        "    <review>An amazing story of nothing.</review>\n" +
-        "  </book>\n" +
-        "  <book id=\"bk002\">\n" +
-        "    <author>Poet</author>\n" +
-        "    <title>The Poet's First Poem</title>\n" +
-                "    <genre>Poem</genre>\n" +
-        "    <price>24.95</price>\n" +
-        "    <review>Least poetic poems.</review>\n" +
-        "  </book>\n" +
-        "</books>\n", s);
+        assertEquals(
+                "<x:books xmlns:x=\"urn:books:qualified\">\n" +
+                "    <x:book id=\"bk001\">\n" +
+                "        <x:author>Writer</x:author>\n" +
+                "        <x:title>The First Book</x:title>\n" +
+                "        <x:genre>Fiction</x:genre>\n" +
+                "        <x:price>44.95</x:price>\n" +
+                "        <x:pub_date>2000-10-01</x:pub_date>\n" +
+                "        <x:review>An amazing story of nothing.</x:review>\n" +
+                "    </x:book>\n" +
+                "\n" +
+                "    <x:book id=\"bk002\">\n" +
+                "        <x:author>Poet</x:author>\n" +
+                "        <x:title>The Poet's First Poem</x:title>\n" +
+                "        <x:genre>Poem</x:genre>\n" +
+                "        <x:price>24.95</x:price>\n" +
+                "        <x:review>Least poetic poems.</x:review>\n" +
+                "    </x:book>\n" +
+                "</x:books>\n",
+                xml.asFormattedString()
+        );
     }
 
     @Test
@@ -112,7 +115,7 @@ public class FralaxQualifiedNamespaceTest {
         final Optional<XmlContext> optionalContext = xml.select("/b:books/b:book[2]");
         assertNotNull(optionalContext);
         assertTrue(optionalContext.isPresent());
-        assertEquals("<x:book id=\"bk002\"><x:author>Poet</x:author><x:title>The Poet's First Poem</x:title><x:genre>Poem</x:genre><x:price>24.95</x:price><x:review>Least poetic poems.</x:review></x:book>",
+        assertEquals("<book id=\"bk002\"><author>Poet</author><title>The Poet's First Poem</title><genre>Poem</genre><price>24.95</price><review>Least poetic poems.</review></book>",
                 optionalContext.get().asString()
         );
     }

--- a/src/test/java/net/onenandone/fralax/FralaxTest.java
+++ b/src/test/java/net/onenandone/fralax/FralaxTest.java
@@ -107,7 +107,7 @@ public class FralaxTest {
                         "  <vehicleId>1</vehicleId>\n" +
                         "  <vehicleId>2</vehicleId>\n" +
                         "</driver>\n",
-                optionalContext.get().asFormattedString()
+                optionalContext.get().asString(true)
         );
     }
 
@@ -116,9 +116,9 @@ public class FralaxTest {
     public void testSelectListOfAttributes() throws Exception {
         final List<XmlContext> contexts = xml.selectAll("//@id");
         assertEquals(3, contexts.size());
-        assertEquals("RR1", contexts.get(0).asFormattedString());
-        assertEquals("AM1", contexts.get(1).asFormattedString());
-        assertEquals("B1", contexts.get(2).asFormattedString());
+        assertEquals("RR1", contexts.get(0).asString(true));
+        assertEquals("AM1", contexts.get(1).asString(true));
+        assertEquals("B1", contexts.get(2).asString(true));
     }
 
     @Test(expected = FralaxException.class)

--- a/src/test/java/net/onenandone/fralax/FralaxUnqualifiedNamespaceTest.java
+++ b/src/test/java/net/onenandone/fralax/FralaxUnqualifiedNamespaceTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
 
 public class FralaxUnqualifiedNamespaceTest {
 

--- a/src/test/java/net/onenandone/fralax/FralaxUnqualifiedNamespaceTest.java
+++ b/src/test/java/net/onenandone/fralax/FralaxUnqualifiedNamespaceTest.java
@@ -109,7 +109,7 @@ public class FralaxUnqualifiedNamespaceTest {
                         "  <pub_date>2000-10-01</pub_date>\n" +
                         "  <review>An amazing story of nothing.</review>\n" +
                         "</book>\n",
-                optionalContext.get().asFormattedString()
+                optionalContext.get().asString(true)
         );
     }
 
@@ -117,8 +117,8 @@ public class FralaxUnqualifiedNamespaceTest {
     public void testSelectListOfAttributes() throws Exception {
         final List<XmlContext> contexts = xml.selectAll("//@id");
         assertEquals(2, contexts.size());
-        assertEquals("bk001", contexts.get(0).asFormattedString());
-        assertEquals("bk002", contexts.get(1).asFormattedString());
+        assertEquals("bk001", contexts.get(0).asString(true));
+        assertEquals("bk002", contexts.get(1).asString(true));
     }
 
     @Test(expected = FralaxException.class)


### PR DESCRIPTION
* Namespaces will be printed if whole XML should be dumped, otherwise namespaces will always be stripped
* Removed `asFormattedString()` and replaced it with `asString(boolean formatted)`